### PR TITLE
WIP: issue-3: changing logging to output to stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ func main() {
 			log.Fatal(err)
 		}
 		log.SetLevel(level)
+		log.SetOutput(os.Stderr)
 
 		return nil
 	}


### PR DESCRIPTION
Tested:

$ NOMAD_ADDR=http://localhost:4646 SINK_TYPE=stdout ./build/nomad-firehose-darwin-amd64 nodes > /dev/null
INFO[0000] Trying to acquire leader lock                
INFO[0000] Lock acquired                                
INFO[0000] Restoring Last Change Time to 0              
INFO[0010] Writing lastChangedTime to KV: 6             
^CINFO[0014] Caught signal, releasing lock and stopping... 
INFO[0014] [sink/stdout] ensure writer queue is empty (0 messages left) 
INFO[0014] Writing lastChangedTime to KV: 6             


$ NOMAD_ADDR=http://localhost:4646 SINK_TYPE=stdout ./build/nomad-firehose-darwin-amd64 nodes 2> /dev/null
$ # no output

closes #3 