### PR TITLE
Implement a new NSQ sink

### DIFF
--- a/sink/helper.go
+++ b/sink/helper.go
@@ -9,7 +9,7 @@ import (
 func GetSink() (Sink, error) {
 	sinkType := os.Getenv("SINK_TYPE")
 	if sinkType == "" {
-		return nil, fmt.Errorf("Missing SINK_TYPE: amqp, kafka,kinesis or stdout")
+		return nil, fmt.Errorf("Missing SINK_TYPE: amqp, kafka, kinesis, nsq or stdout")
 	}
 
 	switch sinkType {
@@ -23,7 +23,9 @@ func GetSink() (Sink, error) {
 		return NewKinesis()
 	case "stdout":
 		return NewStdout()
+	case "nsq":
+		return NewNSQ()
 	default:
-		return nil, fmt.Errorf("Invalid SINK_TYPE: %s, Valid values: amqp, kafka, kinesis or stdout",sinkType)
+		return nil, fmt.Errorf("Invalid SINK_TYPE: %s, Valid values: amqp, kafka, kinesis, nsq or stdout", sinkType)
 	}
 }

--- a/sink/nsq.go
+++ b/sink/nsq.go
@@ -1,0 +1,96 @@
+package sink
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/nsqio/go-nsq"
+)
+
+type NSQSink struct {
+	producer  *nsq.Producer
+	topicName string
+	stopCh    chan interface{}
+	putCh     chan []byte
+}
+
+func NewNSQ() (*NSQSink, error) {
+
+	addrNSQ := os.Getenv("SINK_NSQ_ADDR")
+	if addrNSQ == "" {
+		return nil, fmt.Errorf("[sink/nsq] Missing SINK_NSQ_ADDR (example: 127.0.0.1:4150)")
+	}
+	log.Infof("[sink/nsq] SINK_NSQ_ADDR=%s", addrNSQ)
+
+	topicName := os.Getenv("SINK_NSQ_TOPIC_NAME")
+	if topicName == "" {
+		return nil, fmt.Errorf("[sink/nsq] Missing SINK_NSQ_TOPIC_NAME (example: nomad-firehose)")
+	}
+	log.Infof("[sink/nsq] SINK_NSQ_TOPIC_NAME=%s", topicName)
+
+	conf := nsq.NewConfig()
+	producer, err := nsq.NewProducer(addrNSQ, conf)
+	if err != nil {
+		return nil, fmt.Errorf("[sink/nsq] Failed to connect to NSQ: %v", err)
+	}
+
+	return &NSQSink{
+		producer:  producer,
+		topicName: topicName,
+		stopCh:    make(chan interface{}),
+		putCh:     make(chan []byte, 1000),
+	}, nil
+}
+
+func (s *NSQSink) Start() error {
+	// Stop chan for all tasks to depend on
+	s.stopCh = make(chan interface{})
+
+	// have 1 writer to NSQ
+	go s.write(1)
+
+	// wait forever for a stop signal to happen
+	for {
+		select {
+		case <-s.stopCh:
+			break
+		}
+		break
+	}
+
+	return nil
+}
+
+func (s *NSQSink) Stop() {
+	log.Infof("[sink/nsq] ensure write queue is empty (%d messages left)", len(s.putCh))
+
+	for len(s.putCh) > 0 {
+		log.Infof("[sink/nsq] Waiting for queue to drain - (%d messages left)", len(s.putCh))
+		time.Sleep(1 * time.Second)
+	}
+
+	close(s.stopCh)
+}
+
+func (s *NSQSink) Put(data []byte) error {
+	s.putCh <- data
+
+	return nil
+}
+
+func (s *NSQSink) write(id int) {
+	log.Infof("[sink/nsq/%d] Starting writer", id)
+
+	for {
+		select {
+		case data := <-s.putCh:
+			if err := s.producer.Publish(s.topicName, data); err != nil {
+				log.Infof("[sink/nsq/%d] %s", id, err)
+			} else {
+				log.Infof("[sink/nsq/%d] Publish OK", id)
+			}
+		}
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -349,6 +349,12 @@
 			"revisionTime": "2017-05-08T17:38:06Z"
 		},
 		{
+			"checksumSHA1": "MZdppx6laedD1LcVomiZ/Sfa6rE=",
+			"path": "github.com/nsqio/go-nsq",
+			"revision": "8c1ff52dff6fd3ecc19c418649bc643b18e862fc",
+			"revisionTime": "2017-10-30T00:05:02Z"
+		},
+		{
 			"checksumSHA1": "FGg99nQ56Fo3radSCuU1AeEUJug=",
 			"path": "github.com/pierrec/lz4",
 			"revision": "08c27939df1bd95e881e2c2367a749964ad1fceb",


### PR DESCRIPTION
This PR implements a new sink type: NSQ (http://nsq.io/).

Testing can be done using the `nsqio/nsq` Docker images: http://nsq.io/deployment/docker.html