### PR TITLE
Make Consul session and KV keys configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This will create a `nomad-firehose` binary in your `$GOPATH/bin` directory.
 
 Any `NOMAD_*` env that the native `nomad` CLI tool supports are supported by this tool.
 
-Any `CONSUL_*` env that the native `consul` CLI tool supports are supported by this tool.
+Any `CONSUL_*` env that the native `consul` CLI tool supports are supported by this tool. Additionally, the variables `CONSUL_LOCK_PREFIX` (default `nomad-firehose/`) and `CONSUL_SESSION_NAME` (default `nomad-firehose-allocations`) control where leader locks are stored.
 
 The most basic requirement is `export NOMAD_ADDR=http://<ip>:4646` and `export CONSUL_HTTP_ADDR=<ip>:8500`.
 
@@ -45,11 +45,11 @@ This mean you can run more than 1 process of each firehose, and only one will ac
 
 Saving the last event time mean that restarting the process won't firehose all old changes to your sink, reducing duplicated events.
 
-The Consul lock is maintained in KV at `nomad-firehose/${type}.lock` and the last event time is stored in KV at `nomad-firehose/${type}.value`.
+The Consul lock is maintained in KV at `$CONSUL_LOCK_PREFIX/${type}.lock` and the last event time is stored in KV at `$CONSUL_LOCK_PREFIX/${type}.value`.
 
 #### Consul ACL Token Permissions
 
-If the Consul cluster being used is running ACLs, the following ACL policy will allow the required access:
+If the Consul cluster being used is running ACLs, the following ACL policy will allow the required access, given the default values for `CONSUL_LOCK_PREFIX` and `CONSUL_SESSION_NAME`:
 
 ```hcl
 key "nomad-firehose" {

--- a/command/allocations/app.go
+++ b/command/allocations/app.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	consulLockKey   = "nomad-firehose/allocations.lock"
-	consulLockValue = "nomad-firehose/allocations.value"
+	consulLockKey   = "allocations.lock"
+	consulLockValue = "allocations.value"
 )
 
 // Firehose ...

--- a/command/deployments/app.go
+++ b/command/deployments/app.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	consulLockKey   = "nomad-firehose/deployments.lock"
-	consulLockValue = "nomad-firehose/deployments.value"
+	consulLockKey   = "deployments.lock"
+	consulLockValue = "deployments.value"
 )
 
 // Firehose ...

--- a/command/evaluations/app.go
+++ b/command/evaluations/app.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	consulLockKey   = "nomad-firehose/evaluations.lock"
-	consulLockValue = "nomad-firehose/evaluations.value"
+	consulLockKey   = "evaluations.lock"
+	consulLockValue = "evaluations.value"
 )
 
 // Firehose ...

--- a/command/jobs/app.go
+++ b/command/jobs/app.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	consulLockKey   = "nomad-firehose/jobs.lock"
-	consulLockValue = "nomad-firehose/jobs.value"
+	consulLockKey   = "jobs.lock"
+	consulLockValue = "jobs.value"
 )
 
 // Firehose ...

--- a/command/nodes/app.go
+++ b/command/nodes/app.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	consulLockKey   = "nomad-firehose/clients.lock"
-	consulLockValue = "nomad-firehose/clients.value"
+	consulLockKey   = "clients.lock"
+	consulLockValue = "clients.value"
 )
 
 // Firehose ...


### PR DESCRIPTION
We occasionally spin up additional Nomad clusters for testing, and all our clusters utilize the same Consul cluster. This change makes the Consul keys configurable so that we can operate distinct `nomad-firehose` instances per cluster with one Consul cluster.

I built locally and tested this against a local Consul instance.