### PR TITLE
jobliststubs command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,13 @@ The output will be equal to the [Nomad Evaluation API structure](https://www.nom
 
 `nomad-firehose jobs` will monitor all job changes in the Nomad cluster and emit a firehose event per change to the configured sink.
 
-The output will be equal to the *full* [Nomad Job API structure](https://www.nomadproject.io/api/jobs.html)
+The output will be equal to the *full* [Nomad Job API structure](https://www.nomadproject.io/api/jobs.html#read-job)
+
+### `jobliststubs`
+
+`nomad-firehose jobliststubs` will monitor all job changes in the Nomad cluster and emit a firehose event per change to the configured sink.
+
+The output will be equal to the job list [Nomad Job API structure](https://www.nomadproject.io/api/jobs.html#list-jobs)
 
 ### `deployments`
 

--- a/command/jobs/job.go
+++ b/command/jobs/job.go
@@ -1,0 +1,53 @@
+package jobs
+
+import (
+	"encoding/json"
+
+	nomad "github.com/hashicorp/nomad/api"
+	log "github.com/sirupsen/logrus"
+)
+
+// Firehose ...
+type Firehose struct {
+	FirehoseBase
+}
+
+// NewFirehose ...
+func NewFirehose() (*Firehose, error) {
+	base, err := NewFirehoseBase()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Firehose{FirehoseBase: *base}, nil
+}
+
+
+// Publish an update from the firehose
+func (f *FirehoseBase) Publish(update *nomad.Job) {
+	b, err := json.Marshal(update)
+	if err != nil {
+		log.Error(err)
+	}
+
+	f.sink.Put(b)
+}
+
+func (f *Firehose) watch() {
+	go f.FirehoseBase.watch()
+
+	for {
+		select {
+		case job := <- f.jobListSink:
+			go func(jobID string) {
+				fullJob, _, err := f.nomadClient.Jobs().Info(jobID, &nomad.QueryOptions{})
+				if err != nil {
+					log.Errorf("Could not read job %s: %s", jobID, err)
+					return
+				}
+
+				f.Publish(fullJob)
+			}(job.ID)
+		}
+	}
+}

--- a/command/jobs/jobsliststub.go
+++ b/command/jobs/jobsliststub.go
@@ -1,0 +1,47 @@
+package jobs
+
+import (
+	"encoding/json"
+
+	nomad "github.com/hashicorp/nomad/api"
+	log "github.com/sirupsen/logrus"
+)
+
+// Firehose ...
+type JobListStubFirehose struct {
+	FirehoseBase
+}
+
+// NewFirehose ...
+func NewJobListStubFirehose() (*JobListStubFirehose, error) {
+	base, err := NewFirehoseBase()
+	if err != nil {
+		return nil, err
+	}
+
+	return &JobListStubFirehose{FirehoseBase: *base}, nil
+}
+
+func (f *JobListStubFirehose) Name() string {
+	return "jobliststub"
+}
+
+func (f *JobListStubFirehose) Start() {
+	f.FirehoseBase.Start(f.watchJobList)
+}
+
+// Publish an update from the firehose
+func (f *JobListStubFirehose) Publish(update *nomad.JobListStub) {
+	b, err := json.Marshal(update)
+	if err != nil {
+		log.Error(err)
+	}
+
+	f.sink.Put(b)
+}
+
+func (f *JobListStubFirehose) watchJobList(job *nomad.JobListStub) {
+	f.Publish(job)
+}
+
+

--- a/main.go
+++ b/main.go
@@ -94,7 +94,25 @@ func main() {
 			Name:  "jobs",
 			Usage: "Firehose nomad job changes",
 			Action: func(c *cli.Context) error {
-				firehose, err := jobs.NewFirehose()
+				firehose, err := jobs.NewJobFirehose()
+				if err != nil {
+					return err
+				}
+
+				manager := helper.NewManager(firehose)
+				if err := manager.Start(); err != nil {
+					log.Fatal(err)
+					return err
+				}
+
+				return nil
+			},
+		},
+		{
+			Name:  "jobliststubs",
+			Usage: "Firehose nomad job info changes",
+			Action: func(c *cli.Context) error {
+				firehose, err := jobs.NewJobListStubFirehose()
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
I need to read job summaries even after the nomad GC deleted them, current implementation stores the full job json, but it lacking job summary.

This PR adds new command jobliststubs to read https://www.nomadproject.io/api/jobs.html#list-jobs only