### PR TITLE
Allow to set mongo id from object field

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -101,12 +101,18 @@
   version = "v1.6.0"
 
 [[projects]]
-  digest = "1:c4a2528ccbcabf90f9f3c464a5fc9e302d592861bbfd0b7135a7de8a943d0406"
-  name = "github.com/go-stack/stack"
-  packages = ["."]
+  digest = "1:4b08116de0de75c041bb341686f0b139930f26cb84dfdf7641d435548114181d"
+  name = "github.com/globalsign/mgo"
+  packages = [
+    ".",
+    "bson",
+    "internal/json",
+    "internal/sasl",
+    "internal/scram",
+  ]
   pruneopts = "UT"
-  revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
-  version = "v1.7.0"
+  revision = "113d3961e7311526535a1ef7042196563d442761"
+  version = "r2018.06.15"
 
 [[projects]]
   branch = "master"
@@ -287,69 +293,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:e3492bfc9acbe6e04b51fe36220f9aea8c919885632f0de55685db80c0029844"
-  name = "github.com/mongodb/mongo-go-driver"
-  packages = [
-    "bson",
-    "bson/bsoncodec",
-    "bson/bsoncore",
-    "bson/bsonrw",
-    "bson/bsontype",
-    "bson/decimal",
-    "bson/elements",
-    "bson/objectid",
-    "bson/parser",
-    "bson/parser/ast",
-    "core/address",
-    "core/auth",
-    "core/auth/internal/gssapi",
-    "core/command",
-    "core/compressor",
-    "core/connection",
-    "core/connstring",
-    "core/description",
-    "core/dispatch",
-    "core/event",
-    "core/option",
-    "core/readconcern",
-    "core/readpref",
-    "core/result",
-    "core/session",
-    "core/tag",
-    "core/topology",
-    "core/uuid",
-    "core/version",
-    "core/wiremessage",
-    "core/writeconcern",
-    "internal",
-    "mongo",
-    "mongo/aggregateopt",
-    "mongo/bulkwriteopt",
-    "mongo/changestreamopt",
-    "mongo/clientopt",
-    "mongo/collectionopt",
-    "mongo/countopt",
-    "mongo/dbopt",
-    "mongo/deleteopt",
-    "mongo/distinctopt",
-    "mongo/dropcollopt",
-    "mongo/findopt",
-    "mongo/indexopt",
-    "mongo/insertopt",
-    "mongo/listcollectionopt",
-    "mongo/listdbopt",
-    "mongo/mongoopt",
-    "mongo/replaceopt",
-    "mongo/runcmdopt",
-    "mongo/sessionopt",
-    "mongo/transactionopt",
-    "mongo/updateopt",
-  ]
-  pruneopts = "UT"
-  revision = "8db96a607cde2fea156d9a72c26aa09271592591"
-  version = "v0.0.17"
-
-[[projects]]
   digest = "1:bb48459ec76efe45f13094480296462ef5c9aaa56662918819b7a8fce3155b8b"
   name = "github.com/nsqio/go-nsq"
   packages = ["."]
@@ -407,45 +350,12 @@
   revision = "0053ebfd9d0ee06ccefbfe17072021e1d4acebee"
 
 [[projects]]
-  digest = "1:8e214e348491ae6a1a79c5bb728ed4eca7f1a2892cd66ad11f46558d684333f4"
-  name = "github.com/xdg/scram"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "b32d4bd2c91c5a4f0ea2a230da4350051b5fb5b0"
-
-[[projects]]
   branch = "master"
-  digest = "1:f5c1d04bc09c644c592b45b9f0bad4030521b1a7d11c7dadbb272d9439fa6e8e"
-  name = "github.com/xdg/stringprep"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "73f8eece6fdcd902c185bf651de50f3828bed5ed"
-
-[[projects]]
-  branch = "master"
-  digest = "1:7465b577175e95c0d368c60c10f6e921907fdfe23bcdc7e8452f69a62edd74ac"
+  digest = "1:8db39ece54390c0808fc3822518339fd8dfdceb27e088485998fe5cd0ba0acd7"
   name = "golang.org/x/crypto"
-  packages = [
-    "blake2b",
-    "pbkdf2",
-  ]
+  packages = ["blake2b"]
   pruneopts = "UT"
   revision = "e4dc69e5b2fd71dcaf8bd5d054eb936deb78d1fa"
-
-[[projects]]
-  branch = "master"
-  digest = "1:76ee51c3f468493aff39dbacc401e8831fbb765104cbf613b89bef01cf4bad70"
-  name = "golang.org/x/net"
-  packages = ["context"]
-  pruneopts = "UT"
-  revision = "03003ca0c849e57b6ea29a4bab8d3cb6e4d568fe"
-
-[[projects]]
-  digest = "1:e0140c0c868c6e0f01c0380865194592c011fe521d6e12d78bfd33e756fe018a"
-  name = "golang.org/x/sync"
-  packages = ["semaphore"]
-  pruneopts = "UT"
-  revision = "fd80eb99c8f653c847d294a001bdf2a3a6f768f5"
 
 [[projects]]
   branch = "master"
@@ -457,21 +367,6 @@
   ]
   pruneopts = "UT"
   revision = "66b7b1311ac80bbafcd2daeef9a5e6e2cd1e2399"
-
-[[projects]]
-  digest = "1:8029e9743749d4be5bc9f7d42ea1659471767860f0cdc34d37c3111bd308a295"
-  name = "golang.org/x/text"
-  packages = [
-    "internal/gen",
-    "internal/triegen",
-    "internal/ucd",
-    "transform",
-    "unicode/cldr",
-    "unicode/norm",
-  ]
-  pruneopts = "UT"
-  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
-  version = "v0.3.0"
 
 [[projects]]
   digest = "1:b24d38b282bacf9791408a080f606370efa3d364e4b5fd9ba0f7b87786d3b679"
@@ -490,9 +385,10 @@
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/kinesis",
     "github.com/garyburd/redigo/redis",
+    "github.com/globalsign/mgo",
+    "github.com/globalsign/mgo/bson",
     "github.com/hashicorp/consul/api",
     "github.com/hashicorp/nomad/api",
-    "github.com/mongodb/mongo-go-driver/mongo",
     "github.com/nsqio/go-nsq",
     "github.com/seatgeek/logrus-gelf-formatter",
     "github.com/sirupsen/logrus",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,8 +46,8 @@
   version = "0.8.6"
 
 [[constraint]]
-  name = "github.com/mongodb/mongo-go-driver"
-  version = "0.0.17"
+  name = "github.com/globalsign/mgo"
+  version = "r2018.06.15"
 
 [[constraint]]
   name = "github.com/nsqio/go-nsq"

--- a/sink/mongodb.go
+++ b/sink/mongodb.go
@@ -19,7 +19,9 @@ type MongodbSink struct {
 	session     *mgo.Session
 	database    string
 	collection  string
+	idField     string
 	workerCount int
+	timestamps  bool
 	stopCh      chan interface{}
 	putCh       chan []byte
 }
@@ -40,6 +42,8 @@ func NewMongodb() (*MongodbSink, error) {
 	if collection == "" {
 		return nil, fmt.Errorf("[sink/mongodb] Missing SINK_MONGODB_COLLECTION")
 	}
+
+	idField := os.Getenv("SINK_MONGODB_ID")
 
 	workerCountStr := os.Getenv("SINK_MONGODB_WORKERS")
 	if workerCountStr == "" {
@@ -65,6 +69,7 @@ func NewMongodb() (*MongodbSink, error) {
 		session:     session,
 		database:    database,
 		collection:  collection,
+		idField:     idField,
 		workerCount: workerCount,
 		stopCh:      make(chan interface{}),
 		putCh:       make(chan []byte, 1000),
@@ -126,9 +131,18 @@ func (s *MongodbSink) write(id int) {
 				log.Errorf("[sink/mongodb/%d] %s", id, err)
 				continue
 			}
-			idRecord := bson.M{}
-			update := bson.M{"$set": record}
-			_, err = c.Upsert(idRecord, update)
+
+			if (s.idField != "") {
+				id := record[s.idField].(string)
+				if (id == "") {
+					log.Errorf("[sink/mongodb/%d] missing id field $s", id, s.idField)
+					continue
+				}
+				_, err = c.UpsertId(bson.ObjectIdHex(id), update)
+			} else {
+				err = c.Insert(update)
+			}
+
 			if err != nil {
 				log.Errorf("[sink/mongodb/%d] %s", id, err)
 			} else {


### PR DESCRIPTION
Adds new config variable to mongosink SINK_MONGODB_ID.
for example, setting `SINK_MONGODB_ID=ID` will use the ID field from data as the mongo document Id