### PR TITLE
Write kafka key to partition 

### DIFF
--- a/command/allocations/app.go
+++ b/command/allocations/app.go
@@ -125,13 +125,13 @@ func (f *Firehose) persistLastChangeTime(interval time.Duration) {
 }
 
 // publish an update from the firehose
-func (f *Firehose) publish(key string, update *AllocationUpdate) {
+func (f *Firehose) publish(update *AllocationUpdate) {
 	b, err := json.Marshal(update)
 	if err != nil {
 		log.Error(err)
 	}
 
-	f.sink.Put(key, b)
+	f.sink.Put(update.AllocationID, b)
 }
 
 // Continously watch for changes to the allocation list and publish it as updates
@@ -194,7 +194,7 @@ func (f *Firehose) watch() {
 						TaskFinishedAt:     &taskInfo.FinishedAt,
 					}
 
-					f.publish(allocation.ID, payload)
+					f.publish(payload)
 				}
 			}
 		}

--- a/command/allocations/app.go
+++ b/command/allocations/app.go
@@ -125,13 +125,13 @@ func (f *Firehose) persistLastChangeTime(interval time.Duration) {
 }
 
 // publish an update from the firehose
-func (f *Firehose) publish(update *AllocationUpdate) {
+func (f *Firehose) publish(key string, update *AllocationUpdate) {
 	b, err := json.Marshal(update)
 	if err != nil {
 		log.Error(err)
 	}
 
-	f.sink.Put(b)
+	f.sink.Put(key, b)
 }
 
 // Continously watch for changes to the allocation list and publish it as updates
@@ -194,7 +194,7 @@ func (f *Firehose) watch() {
 						TaskFinishedAt:     &taskInfo.FinishedAt,
 					}
 
-					f.publish(payload)
+					f.publish(allocation.ID, payload)
 				}
 			}
 		}

--- a/command/deployments/app.go
+++ b/command/deployments/app.go
@@ -111,13 +111,13 @@ func (f *Firehose) persistLastChangeTime(interval time.Duration) {
 }
 
 // Publish an update from the firehose
-func (f *Firehose) Publish(key string, update *nomad.Deployment) {
+func (f *Firehose) Publish(update *nomad.Deployment) {
 	b, err := json.Marshal(update)
 	if err != nil {
 		log.Error(err)
 	}
 
-	f.sink.Put(key, b)
+	f.sink.Put(update.ID, b)
 }
 
 // Continously watch for changes to the deployment list and publish it as updates
@@ -166,7 +166,7 @@ func (f *Firehose) watch() {
 					return
 				}
 
-				f.Publish(DeploymentID, fullDeployment)
+				f.Publish(fullDeployment)
 			}(deployment.ID)
 		}
 

--- a/command/deployments/app.go
+++ b/command/deployments/app.go
@@ -111,13 +111,13 @@ func (f *Firehose) persistLastChangeTime(interval time.Duration) {
 }
 
 // Publish an update from the firehose
-func (f *Firehose) Publish(update *nomad.Deployment) {
+func (f *Firehose) Publish(key string, update *nomad.Deployment) {
 	b, err := json.Marshal(update)
 	if err != nil {
 		log.Error(err)
 	}
 
-	f.sink.Put(b)
+	f.sink.Put(key, b)
 }
 
 // Continously watch for changes to the deployment list and publish it as updates
@@ -166,7 +166,7 @@ func (f *Firehose) watch() {
 					return
 				}
 
-				f.Publish(fullDeployment)
+				f.Publish(DeploymentID, fullDeployment)
 			}(deployment.ID)
 		}
 

--- a/command/evaluations/app.go
+++ b/command/evaluations/app.go
@@ -105,13 +105,13 @@ func (f *Firehose) persistLastChangeTime(interval time.Duration) {
 }
 
 // Publish an update from the firehose
-func (f *Firehose) Publish(update *nomad.Evaluation) {
+func (f *Firehose) Publish(key string, update *nomad.Evaluation) {
 	b, err := json.Marshal(update)
 	if err != nil {
 		log.Error(err)
 	}
 
-	f.sink.Put(b)
+	f.sink.Put(key, b)
 }
 
 // Continously watch for changes to the allocation list and publish it as updates
@@ -146,7 +146,7 @@ func (f *Firehose) watch() {
 				continue
 			}
 
-			f.Publish(evaluation)
+			f.Publish(evaluation.ID, evaluation)
 			evaluation = nil
 		}
 

--- a/command/evaluations/app.go
+++ b/command/evaluations/app.go
@@ -105,13 +105,13 @@ func (f *Firehose) persistLastChangeTime(interval time.Duration) {
 }
 
 // Publish an update from the firehose
-func (f *Firehose) Publish(key string, update *nomad.Evaluation) {
+func (f *Firehose) Publish(update *nomad.Evaluation) {
 	b, err := json.Marshal(update)
 	if err != nil {
 		log.Error(err)
 	}
 
-	f.sink.Put(key, b)
+	f.sink.Put(update.ID, b)
 }
 
 // Continously watch for changes to the allocation list and publish it as updates
@@ -146,7 +146,7 @@ func (f *Firehose) watch() {
 				continue
 			}
 
-			f.Publish(evaluation.ID, evaluation)
+			f.Publish(evaluation)
 			evaluation = nil
 		}
 

--- a/command/jobs/base.go
+++ b/command/jobs/base.go
@@ -9,9 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-
 type WatchJobListFunc func(job *nomad.JobListStub)
-
 
 // Firehose ...
 type FirehoseBase struct {

--- a/command/jobs/job.go
+++ b/command/jobs/job.go
@@ -22,7 +22,6 @@ func NewJobFirehose() (*JobFirehose, error) {
 	return &JobFirehose{FirehoseBase: *base}, nil
 }
 
-
 func (f *JobFirehose) Name() string {
 	return "jobs"
 }
@@ -36,7 +35,6 @@ func (f *JobFirehose) Publish(update *nomad.Job) {
 
 	f.sink.Put(*update.ID, b)
 }
-
 
 func (f *JobFirehose) Start() {
 	f.FirehoseBase.Start(f.watchJobList)

--- a/command/jobs/job.go
+++ b/command/jobs/job.go
@@ -28,13 +28,13 @@ func (f *JobFirehose) Name() string {
 }
 
 // Publish an update from the firehose
-func (f *JobFirehose) Publish(key string, update *nomad.Job) {
+func (f *JobFirehose) Publish(update *nomad.Job) {
 	b, err := json.Marshal(update)
 	if err != nil {
 		log.Error(err)
 	}
 
-	f.sink.Put(key, b)
+	f.sink.Put(*update.ID, b)
 }
 
 
@@ -50,6 +50,6 @@ func (f *JobFirehose) watchJobList(job *nomad.JobListStub) {
 			return
 		}
 
-		f.Publish(jobID, fullJob)
+		f.Publish(fullJob)
 	}(job.ID)
 }

--- a/command/jobs/job.go
+++ b/command/jobs/job.go
@@ -28,13 +28,13 @@ func (f *JobFirehose) Name() string {
 }
 
 // Publish an update from the firehose
-func (f *JobFirehose) Publish(update *nomad.Job) {
+func (f *JobFirehose) Publish(key string, update *nomad.Job) {
 	b, err := json.Marshal(update)
 	if err != nil {
 		log.Error(err)
 	}
 
-	f.sink.Put(b)
+	f.sink.Put(key, b)
 }
 
 
@@ -50,6 +50,6 @@ func (f *JobFirehose) watchJobList(job *nomad.JobListStub) {
 			return
 		}
 
-		f.Publish(fullJob)
+		f.Publish(jobID, fullJob)
 	}(job.ID)
 }

--- a/command/jobs/jobsliststub.go
+++ b/command/jobs/jobsliststub.go
@@ -43,5 +43,3 @@ func (f *JobListStubFirehose) Publish(update *nomad.JobListStub) {
 func (f *JobListStubFirehose) watchJobList(job *nomad.JobListStub) {
 	f.Publish(job)
 }
-
-

--- a/command/jobs/jobsliststub.go
+++ b/command/jobs/jobsliststub.go
@@ -31,17 +31,17 @@ func (f *JobListStubFirehose) Start() {
 }
 
 // Publish an update from the firehose
-func (f *JobListStubFirehose) Publish(key string, update *nomad.JobListStub) {
+func (f *JobListStubFirehose) Publish(update *nomad.JobListStub) {
 	b, err := json.Marshal(update)
 	if err != nil {
 		log.Error(err)
 	}
 
-	f.sink.Put(key, b)
+	f.sink.Put(update.ID, b)
 }
 
 func (f *JobListStubFirehose) watchJobList(job *nomad.JobListStub) {
-	f.Publish("", job)
+	f.Publish(job)
 }
 
 

--- a/command/jobs/jobsliststub.go
+++ b/command/jobs/jobsliststub.go
@@ -31,17 +31,17 @@ func (f *JobListStubFirehose) Start() {
 }
 
 // Publish an update from the firehose
-func (f *JobListStubFirehose) Publish(update *nomad.JobListStub) {
+func (f *JobListStubFirehose) Publish(key string, update *nomad.JobListStub) {
 	b, err := json.Marshal(update)
 	if err != nil {
 		log.Error(err)
 	}
 
-	f.sink.Put(b)
+	f.sink.Put(key, b)
 }
 
 func (f *JobListStubFirehose) watchJobList(job *nomad.JobListStub) {
-	f.Publish(job)
+	f.Publish("", job)
 }
 
 

--- a/command/nodes/app.go
+++ b/command/nodes/app.go
@@ -103,13 +103,13 @@ func (f *Firehose) persistLastChangeTime(interval time.Duration) {
 }
 
 // Publish an update from the firehose
-func (f *Firehose) Publish(key string, update *nomad.Node) {
+func (f *Firehose) Publish(update *nomad.Node) {
 	b, err := json.Marshal(update)
 	if err != nil {
 		log.Error(err)
 	}
 
-	f.sink.Put(key, b)
+	f.sink.Put(update.ID, b)
 }
 
 // Continously watch for changes to the allocation list and publish it as updates
@@ -158,7 +158,7 @@ func (f *Firehose) watch() {
 					return
 				}
 
-				f.Publish(clientId, fullClient)
+				f.Publish(fullClient)
 			}(client.ID)
 		}
 

--- a/command/nodes/app.go
+++ b/command/nodes/app.go
@@ -103,13 +103,13 @@ func (f *Firehose) persistLastChangeTime(interval time.Duration) {
 }
 
 // Publish an update from the firehose
-func (f *Firehose) Publish(update *nomad.Node) {
+func (f *Firehose) Publish(key string, update *nomad.Node) {
 	b, err := json.Marshal(update)
 	if err != nil {
 		log.Error(err)
 	}
 
-	f.sink.Put(b)
+	f.sink.Put(key, b)
 }
 
 // Continously watch for changes to the allocation list and publish it as updates
@@ -158,7 +158,7 @@ func (f *Firehose) watch() {
 					return
 				}
 
-				f.Publish(fullClient)
+				f.Publish(clientId, fullClient)
 			}(client.ID)
 		}
 

--- a/helper/manager.go
+++ b/helper/manager.go
@@ -21,9 +21,9 @@ type Runner interface {
 
 func NewManager(r Runner) *Manager {
 	return &Manager{
-		runner: r,
-		logger: log.WithField("type", r.Name()),
-		stopCh: make(chan interface{}),
+		runner:                   r,
+		logger:                   log.WithField("type", r.Name()),
+		stopCh:                   make(chan interface{}),
 		voluntarilyReleaseLockCh: make(chan interface{}),
 	}
 }

--- a/sink/http.go
+++ b/sink/http.go
@@ -1,9 +1,9 @@
 package sink
 
 import (
+	"bytes"
 	"strconv"
 	"time"
-	"bytes"
 
 	"net/http"
 

--- a/sink/http.go
+++ b/sink/http.go
@@ -80,7 +80,7 @@ func (s *HttpSink) Stop() {
 }
 
 // Put ..
-func (s *HttpSink) Put(data []byte) error {
+func (s *HttpSink) Put(key string, data []byte) error {
 	s.putCh <- data
 
 	return nil

--- a/sink/kafka.go
+++ b/sink/kafka.go
@@ -20,6 +20,8 @@ type KafkaSink struct {
 	// Kafka topic
 	Topic string
 
+	key string
+	
 	producer sarama.SyncProducer
 
 	stopCh chan interface{}
@@ -108,8 +110,9 @@ func (s *KafkaSink) Stop() {
 }
 
 // Put ..
-func (s *KafkaSink) Put(data []byte) error {
+func (s *KafkaSink) Put(key string, data []byte) error {
 	s.putCh <- data
+	s.key <- key
 
 	return nil
 }

--- a/sink/kafka.go
+++ b/sink/kafka.go
@@ -23,7 +23,7 @@ type KafkaSink struct {
 	producer sarama.SyncProducer
 
 	stopCh chan interface{}
-	putCh chan Data
+	putCh  chan Data
 }
 
 func createTlsConfiguration() (t *tls.Config) {
@@ -38,7 +38,7 @@ func createTlsConfiguration() (t *tls.Config) {
 		caCertPool.AppendCertsFromPEM(caCert)
 
 		t = &tls.Config{
-			RootCAs:            caCertPool,
+			RootCAs: caCertPool,
 		}
 	}
 

--- a/sink/kafka.go
+++ b/sink/kafka.go
@@ -21,7 +21,7 @@ type KafkaSink struct {
 	Topic string
 
 	key string
-	
+
 	producer sarama.SyncProducer
 
 	stopCh chan interface{}
@@ -112,7 +112,7 @@ func (s *KafkaSink) Stop() {
 // Put ..
 func (s *KafkaSink) Put(key string, data []byte) error {
 	s.putCh <- data
-	s.key <- key
+	s.key = key
 
 	return nil
 }
@@ -125,6 +125,7 @@ func (s *KafkaSink) write() {
 		case data := <-s.putCh:
 			message := &sarama.ProducerMessage{Topic: s.Topic}
 			message.Value = sarama.StringEncoder(string(data))
+			message.Key = sarama.StringEncoder(s.key)
 			partition, offset, err := s.producer.SendMessage(message)
 			if err != nil {
 				log.Errorf("Failed to produce message: %s", err)

--- a/sink/kinesis.go
+++ b/sink/kinesis.go
@@ -83,7 +83,7 @@ func (s *KinesisSink) Stop() {
 }
 
 // Put ..
-func (s *KinesisSink) Put(data []byte) error {
+func (s *KinesisSink) Put(key string, data []byte) error {
 	s.putCh <- data
 
 	return nil

--- a/sink/kinesis.go
+++ b/sink/kinesis.go
@@ -32,7 +32,6 @@ func NewKinesis() (*KinesisSink, error) {
 
 	partitionKey := os.Getenv("SINK_KINESIS_PARTITION_KEY")
 
-
 	sess := session.Must(session.NewSession())
 	svc := kinesis.New(sess)
 

--- a/sink/kinesis.go
+++ b/sink/kinesis.go
@@ -31,9 +31,7 @@ func NewKinesis() (*KinesisSink, error) {
 	}
 
 	partitionKey := os.Getenv("SINK_KINESIS_PARTITION_KEY")
-	if partitionKey == "" {
-		return nil, fmt.Errorf("[sink/kinesis] Missing SINK_KINESIS_PARTITION_KEY")
-	}
+
 
 	sess := session.Must(session.NewSession())
 	svc := kinesis.New(sess)
@@ -86,6 +84,9 @@ func (s *KinesisSink) Stop() {
 func (s *KinesisSink) Put(key string, data []byte) error {
 	s.putCh <- data
 
+	if s.partitionKey == "" {
+		s.partitionKey = key
+	}
 	return nil
 }
 

--- a/sink/mongodb.go
+++ b/sink/mongodb.go
@@ -7,8 +7,8 @@ import (
 
 	"os"
 
-	"fmt"
 	"encoding/json"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
 
@@ -60,7 +60,6 @@ func NewMongodb() (*MongodbSink, error) {
 	if err != nil {
 		return nil, fmt.Errorf("[sink/mongodb] failed to connect to string: %s", err)
 	}
-
 
 	return &MongodbSink{
 		conn:        conn,

--- a/sink/mongodb.go
+++ b/sink/mongodb.go
@@ -107,7 +107,7 @@ func (s *MongodbSink) Stop() {
 }
 
 // Put ..
-func (s *MongodbSink) Put(data []byte) error {
+func (s *MongodbSink) Put(key string, data []byte) error {
 	s.putCh <- data
 
 	return nil

--- a/sink/nsq.go
+++ b/sink/nsq.go
@@ -74,7 +74,7 @@ func (s *NSQSink) Stop() {
 	close(s.stopCh)
 }
 
-func (s *NSQSink) Put(data []byte) error {
+func (s *NSQSink) Put(key string, data []byte) error {
 	s.putCh <- data
 
 	return nil

--- a/sink/rabbitmq.go
+++ b/sink/rabbitmq.go
@@ -98,7 +98,7 @@ func (s *RabbitmqSink) Stop() {
 }
 
 // Put ..
-func (s *RabbitmqSink) Put(data []byte) error {
+func (s *RabbitmqSink) Put(key string, data []byte) error {
 	s.putCh <- data
 
 	return nil

--- a/sink/redis.go
+++ b/sink/redis.go
@@ -81,7 +81,7 @@ func (s *RedisSink) Stop() {
 }
 
 // Put ..
-func (s *RedisSink) Put(key []byte, data []byte) error {
+func (s *RedisSink) Put(key string, data []byte) error {
 	s.putCh <- data
 	return nil
 }

--- a/sink/redis.go
+++ b/sink/redis.go
@@ -81,7 +81,7 @@ func (s *RedisSink) Stop() {
 }
 
 // Put ..
-func (s *RedisSink) Put(data []byte) error {
+func (s *RedisSink) Put(key []byte, data []byte) error {
 	s.putCh <- data
 	return nil
 }

--- a/sink/stdout.go
+++ b/sink/stdout.go
@@ -10,14 +10,14 @@ import (
 // StdoutSink ...
 type StdoutSink struct {
 	stopCh chan interface{}
-	putCh  chan []byte
+	putCh  chan Data
 }
 
 // NewStdout ...
 func NewStdout() (*StdoutSink, error) {
 	return &StdoutSink{
 		stopCh: make(chan interface{}),
-		putCh:  make(chan []byte, 1000),
+		putCh:  make(chan Data, 1000),
 	}, nil
 }
 
@@ -51,7 +51,7 @@ func (s *StdoutSink) Stop() {
 }
 
 // Put ..
-func (s *StdoutSink) Put(key string, data []byte) error {
-	fmt.Println(string(data))
+func (s *StdoutSink) Put(key string, value []byte) error {
+	fmt.Println(string(value))
 	return nil
 }

--- a/sink/stdout.go
+++ b/sink/stdout.go
@@ -51,7 +51,8 @@ func (s *StdoutSink) Stop() {
 }
 
 // Put ..
-func (s *StdoutSink) Put(data []byte) error {
-	fmt.Println(string(data))
+func (s *StdoutSink) Put(key string, data []byte) error {
+	fmt.Println("key: %s", key)
+	fmt.Println("value: %s", string(data))
 	return nil
 }

--- a/sink/stdout.go
+++ b/sink/stdout.go
@@ -52,6 +52,6 @@ func (s *StdoutSink) Stop() {
 
 // Put ..
 func (s *StdoutSink) Put(key string, data []byte) error {
-	fmt.Printf("key: %s, message: %s\n", key, string(data))
+	fmt.Println(string(data))
 	return nil
 }

--- a/sink/stdout.go
+++ b/sink/stdout.go
@@ -52,7 +52,6 @@ func (s *StdoutSink) Stop() {
 
 // Put ..
 func (s *StdoutSink) Put(key string, data []byte) error {
-	fmt.Println("key: %s", key)
-	fmt.Println("value: %s", string(data))
+	fmt.Printf("key: %s, message: %s\n", key, string(data))
 	return nil
 }

--- a/sink/structs.go
+++ b/sink/structs.go
@@ -4,5 +4,5 @@ package sink
 type Sink interface {
 	Start() error
 	Stop()
-	Put(data []byte) error
+	Put(key string, data []byte) error
 }

--- a/sink/structs.go
+++ b/sink/structs.go
@@ -6,3 +6,8 @@ type Sink interface {
 	Stop()
 	Put(key string, data []byte) error
 }
+
+type Data struct {
+	key string
+	value []byte
+}

--- a/sink/structs.go
+++ b/sink/structs.go
@@ -8,6 +8,6 @@ type Sink interface {
 }
 
 type Data struct {
-	key string
+	key   string
 	value []byte
 }


### PR DESCRIPTION
Modifies structs to take in a string 'key' (in addition to the data []byte) so the commands (allocation/jobs/nodes) can write the IDs to the key for kafka absolute order partitioning.

should have no effect on other sinks, as the key argument is ignored in the Put().

tested locally.