### PR TITLE
Fix leaking sockets in HTTP Sink

### DIFF
--- a/sink/http.go
+++ b/sink/http.go
@@ -92,10 +92,11 @@ func (s *HttpSink) send(id int) {
 	for {
 		select {
 		case data := <-s.putCh:
-			_, err := http.Post(s.address, "application/json; charset=utf-8", bytes.NewBuffer(data[:]))
+			resp, err := http.Post(s.address, "application/json; charset=utf-8", bytes.NewBuffer(data[:]))
 			if err != nil {
 				log.Errorf("[sink/http/%d] %s", id, err)
 			} else {
+				defer resp.Body.Close()
 				log.Debugf("[sink/http/%d] publish ok", id)
 			}
 		}


### PR DESCRIPTION
According to [Golang Docs](https://golang.org/pkg/net/http/#pkg-overview), you should always close HTTP response body, otherwise the underlying socket keeps open and you are leaking file descriptors on the server.