### PR TITLE
Add "syslog" firehose sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,22 +78,25 @@ The sink type is configured using `$SINK_TYPE` environment variable. Valid value
 - `kafka`
 - `mongo`
 - `stdout`
+- `syslog`
 
-The `amqp` sink is configured using `$SINK_AMQP_CONNECTION` (`amqp://guest:guest@127.0.0.1:5672/`), `$SINK_AMQP_EXCHANGE` and `$SINK_AMQP_ROUTING_KEY`, `$SINK_AMQP_WORKERS` (default: `1`) environment variables.
+The `amqp` and `rabbitmq` sinks are configured using `$SINK_AMQP_CONNECTION` (`amqp://guest:guest@127.0.0.1:5672/`), `$SINK_AMQP_EXCHANGE`, `$SINK_AMQP_ROUTING_KEY`, and `$SINK_AMQP_WORKERS` (default: `1`) environment variables.
+
+The `http` sink is configured using `$SINK_HTTP_ADDRESS` (`localhost:8080/allocations`)` environment variable.
+
+The `kafka` sink is configured using `$SINK_KAFKA_BROKERS` (`kafka1:9092,kafka2:9092,kafka3:9092`), and `$SINK_KAFKA_TOPIC` environment variables.
 
 The `kinesis` sink is configured using `$SINK_KINESIS_STREAM_NAME` and `$SINK_KINESIS_PARTITION_KEY` environment variables.
+
+The `mongo` sink is configured using `$SINK_MONGODB_CONNECTION` (`mongodb://localhost:27017/`), `$SINK_MONGODB_DATABASE` and `$SINK_MONGODB_COLLECTION` environment variables.
 
 The `nsq` sink is configured using `$SINK_NSQ_ADDR` and `$SINK_NSQ_TOPIC_NAME` environment variables.
 
 The `redis` sink is configured using `$SINK_REDIS_URL` (`redis://[user]:[password]@127.0.0.1[:5672]/0`) and `$SINK_REDIS_KEY` environment variables.
 
-The `kafka` sink is configured using `$SINK_KAFKA_BROKERS` (`kafka1:9092,kafka2:9092,kafka3:9092`), and `$SINK_KAFKA_TOPIC` environment variables.
-
-The `mongo` sink is configured using `$SINK_MONGODB_CONNECTION` (`mongodb://localhost:27017/`), `$SINK_MONGODB_DATABASE` and `$SINK_MONGODB_COLLECTION` environment variables.
-
-The `http` sink is configured using `$SINK_HTTP_ADDRESS` (`localhost:8080/allocations`)` environment variable.
-
 The `stdout` sink does not have any configuration, it will simply output the JSON to stdout for debugging.
+
+The `syslog` sink is configured using `$SINK_SYSLOG_PROTO` (e.g. `tcp`, `udp` - leave empty if logging to a local syslog socket), `$SINK_SYSLOG_ADDR` (e.g. `127.0.0.1:514` - leave empty if logging to a local syslog socket), and `$SINK_SYSLOG_TAG` (default: `nomad-firehose`).
 
 ### `allocations`
 

--- a/main.go
+++ b/main.go
@@ -45,13 +45,12 @@ func main() {
 			Action: func(c *cli.Context) error {
 				firehose, err := allocations.NewFirehose()
 				if err != nil {
-					return err
+					log.Fatal(err)
 				}
 
 				manager := helper.NewManager(firehose)
 				if err := manager.Start(); err != nil {
 					log.Fatal(err)
-					return err
 				}
 
 				return nil
@@ -63,13 +62,12 @@ func main() {
 			Action: func(c *cli.Context) error {
 				firehose, err := nodes.NewFirehose()
 				if err != nil {
-					return err
+					log.Fatal(err)
 				}
 
 				manager := helper.NewManager(firehose)
 				if err := manager.Start(); err != nil {
 					log.Fatal(err)
-					return err
 				}
 
 				return nil
@@ -81,13 +79,12 @@ func main() {
 			Action: func(c *cli.Context) error {
 				firehose, err := evaluations.NewFirehose()
 				if err != nil {
-					return err
+					log.Fatal(err)
 				}
 
 				manager := helper.NewManager(firehose)
 				if err := manager.Start(); err != nil {
 					log.Fatal(err)
-					return err
 				}
 
 				return nil
@@ -99,13 +96,12 @@ func main() {
 			Action: func(c *cli.Context) error {
 				firehose, err := jobs.NewJobFirehose()
 				if err != nil {
-					return err
+					log.Fatal(err)
 				}
 
 				manager := helper.NewManager(firehose)
 				if err := manager.Start(); err != nil {
 					log.Fatal(err)
-					return err
 				}
 
 				return nil
@@ -117,13 +113,12 @@ func main() {
 			Action: func(c *cli.Context) error {
 				firehose, err := jobs.NewJobListStubFirehose()
 				if err != nil {
-					return err
+					log.Fatal(err)
 				}
 
 				manager := helper.NewManager(firehose)
 				if err := manager.Start(); err != nil {
 					log.Fatal(err)
-					return err
 				}
 
 				return nil
@@ -135,13 +130,12 @@ func main() {
 			Action: func(c *cli.Context) error {
 				firehose, err := deployments.NewFirehose()
 				if err != nil {
-					return err
+					log.Fatal(err)
 				}
 
 				manager := helper.NewManager(firehose)
 				if err := manager.Start(); err != nil {
 					log.Fatal(err)
-					return err
 				}
 
 				return nil

--- a/sink/helper.go
+++ b/sink/helper.go
@@ -9,29 +9,31 @@ import (
 func GetSink() (Sink, error) {
 	sinkType := os.Getenv("SINK_TYPE")
 	if sinkType == "" {
-		return nil, fmt.Errorf("Missing SINK_TYPE: amqp, kafka, kinesis, nsq, rabbitmq, redis, mongodb, http or stdout")
+		return nil, fmt.Errorf("Missing SINK_TYPE: amqp, http, kafka, kinesis, mongodb, nsq, rabbitmq, redis, stdout, syslog")
 	}
 
 	switch sinkType {
 	case "amqp":
 		return NewRabbitmq()
-	case "rabbitmq":
-		return NewRabbitmq()
+	case "http":
+		return NewHttp()
 	case "kafka":
 		return NewKafka()
 	case "kinesis":
 		return NewKinesis()
-	case "nsq":
-		return NewNSQ()
-	case "redis":
-		return NewRedis()
 	case "mongodb":
 		return NewMongodb()
-	case "http":
-		return NewHttp()
+	case "nsq":
+		return NewNSQ()
+	case "rabbitmq":
+		return NewRabbitmq()
+	case "redis":
+		return NewRedis()
 	case "stdout":
 		return NewStdout()
+	case "syslog":
+		return NewSyslog()
 	default:
-		return nil, fmt.Errorf("Invalid SINK_TYPE: %s, Valid values: amqp, kafka, kinesis, nsq, rabbitmq, redis, mongodb, http or stdout", sinkType)
+		return nil, fmt.Errorf("Invalid SINK_TYPE: %s, Valid values: amqp, http, kafka, kinesis, mongodb, nsq, rabbitmq, redis, stdout, syslog", sinkType)
 	}
 }

--- a/sink/syslog_unix.go
+++ b/sink/syslog_unix.go
@@ -1,0 +1,112 @@
+// +build darwin linux
+
+package sink
+
+import (
+	"fmt"
+	"log/syslog"
+	"os"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type SyslogSink struct {
+	addr     string
+	proto    string
+	priority syslog.Priority
+	tag      string
+	stopCh   chan interface{}
+	putCh    chan []byte
+}
+
+// NewSyslog ...
+func NewSyslog() (*SyslogSink, error) {
+	syslogProto := os.Getenv("SINK_SYSLOG_PROTO")
+	// The log/syslog package has some interesting internal behaviours. If we
+	// *do not* supply the network protocol, syslog.Dial assumes we are
+	// connecting to a local syslog socket and configures itself for "local"
+	// mode, which does not include the local hostname in messages written to
+	// the socket (and avoids breaking a standard).
+	//
+	// See: https://github.com/golang/go/commit/87a6d75012986fb8867b746afcd42f742c119945
+	if syslogProto == "" {
+		log.Info("[sink/syslog] SINK_SYSLOG_PROTO not set - ignoring this and SINK_SYSLOG_ADDR, as syslog package will default to unixgram and an autodiscovered socket")
+	}
+	syslogAddr := os.Getenv("SINK_SYSLOG_ADDR")
+	if syslogAddr == "" && syslogProto != "" {
+		return nil, fmt.Errorf("[sink/syslog] Missing SINK_SYSLOG_ADDR (examples: 192.168.1.100:514")
+	}
+	syslogTag := os.Getenv("SINK_SYSLOG_TAG")
+	if syslogTag == "" {
+		log.Info("[sink/syslog] Missing SINK_SYSLOG_TAG - setting to default 'nomad-firehose'")
+		syslogTag = "nomad-firehose"
+	}
+
+	return &SyslogSink{
+		addr:     syslogAddr,
+		proto:    syslogProto,
+		tag:      syslogTag,
+		priority: syslog.LOG_INFO,
+
+		stopCh: make(chan interface{}),
+		putCh:  make(chan []byte, 1000),
+	}, nil
+}
+
+// Start ...
+func (s *SyslogSink) Start() error {
+	// Stop chan for all tasks to depend on
+	s.stopCh = make(chan interface{})
+
+	go s.write()
+
+	// wait forever for a stop signal to happen
+	for {
+		select {
+		case <-s.stopCh:
+			break
+		}
+		break
+	}
+
+	return nil
+}
+
+// Stop ...
+func (s *SyslogSink) Stop() {
+	log.Infof("[sink/syslog] ensure writer queue is empty (%d messages left)", len(s.putCh))
+
+	for len(s.putCh) > 0 {
+		log.Infof("[sink/syslog] Waiting for queue to drain - (%d messages left)", len(s.putCh))
+		time.Sleep(1 * time.Second)
+	}
+
+	close(s.stopCh)
+}
+
+// Put ..
+func (s *SyslogSink) Put(data []byte) error {
+	s.putCh <- data
+	return nil
+}
+
+func (s *SyslogSink) write() error {
+	log.Infof("[sink/syslog] Starting writer - %s://%s - tag: %s", s.proto, s.addr, s.tag)
+	writer, err := syslog.Dial(s.proto, s.addr, syslog.LOG_NOTICE, s.tag)
+	if err != nil {
+		log.Infof("[sink/syslog] ERROR initializing syslog writer: %q", err)
+		return err
+	}
+
+	for {
+		select {
+		case data := <-s.putCh:
+			// fmt.Fprint(writer, string(data))
+			_, err := writer.Write(data)
+			if err != nil {
+				log.Infof("[sink/syslog] ERROR writing to syslog: %q", err)
+			}
+		}
+	}
+}

--- a/sink/syslog_windows.go
+++ b/sink/syslog_windows.go
@@ -1,0 +1,29 @@
+// +build windows
+
+package sink
+
+import (
+	"fmt"
+)
+
+type SyslogSink struct{}
+
+// NewSyslog ...
+func NewSyslog() (*SyslogSink, error) {
+	return &SyslogSink{}, fmt.Errorf("[sink/syslog] ERROR - not supported on Windows :(")
+}
+
+// Put ...
+func (s *SyslogSink) Put(_ []byte) error {
+	return nil
+}
+
+// Start ...
+func (s *SyslogSink) Start() error {
+	return nil
+}
+
+// Stop ...
+func (s *SyslogSink) Stop() {
+	return
+}


### PR DESCRIPTION
## What's changing?

  * Adds a new `syslog` sink type (not currently supported on Windows due to gaps in `log/syslog`)
  * will now return errors during firehose setup (failures were previously silent)
  * updated README (document `syslog` sink; alphabetize sink listing; call out `rabbitmq` configuration).

## Example output

Here's an example syslog message resulting from an invocation of ``SINK_TYPE=syslog ./nomad-firehose allocations`` (also validated with a UDP target):

```
May  6 21:18:03 nomadlab nomad-firehose[6223]: {"Name":"testjob.group2[0]","NodeID":"994ef885-3e76-bab3-9b94-71768a693401", [...] }
```
