### PR TITLE
Use the queue name instead of queue URL in sqs sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ The `stdout` sink does not have any configuration, it will simply output the JSO
 
 The `syslog` sink is configured using `$SINK_SYSLOG_PROTO` (e.g. `tcp`, `udp` - leave empty if logging to a local syslog socket), `$SINK_SYSLOG_ADDR` (e.g. `127.0.0.1:514` - leave empty if logging to a local syslog socket), and `$SINK_SYSLOG_TAG` (default: `nomad-firehose`).
 
-The `sqs` sink is configured using `$SINK_SQS_QUEUE_URL` which should point to the queue URL provided by AWS. This queue is expected to be a FIFO queue.
+The `sqs` sink is configured using `$SINK_SQS_QUEUE_NAME` which is the name of the queue in SQS. This queue is expected to be a FIFO queue.
+The URL of the queue is inferred by the presence of the `AWS_REGION` and `AWS_ACCOUNT_ID` env variables.
 
 ### `allocations`
 


### PR DESCRIPTION
This allows more flexibility when using nomad-firehose with env
variables