### PR TITLE
Enable in transit TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,14 @@ If you've set a custom prefix, specify that in the `key` ACL entry instead.
 
 ### Kafka
 
-To connect to Kafka with TLS, set the SINK_KAFKA_CA_CERT_PATH to the path to your CA cert file.
+### Enable TLS to encrypt data in transit
+To enable TLS communication between client and broker set `SINK_KAFKA_ENABLE_TLS` to `true`. Note that this will be enabled automatically by using [TLS client authentication](#tls)
+
+### Client authentication
+#### TLS
+To connect to Kafka with TLS authentication, set the `SINK_KAFKA_CA_CERT_PATH` to the path to your CA cert file.
+
+#### User/password
 To use SASL/PLAIN authentication, set `$SINK_KAFKA_USER` and `$SINK_KAFKA_PASSWORD` environment variables.
 
 

--- a/sink/kafka.go
+++ b/sink/kafka.go
@@ -70,6 +70,12 @@ func NewKafka() (*KafkaSink, error) {
 		config.Net.TLS.Enable = true
 	}
 
+	// To enable in transing tls
+	enableTLS := os.Getenv("SINK_KAFKA_ENABLE_TLS")
+	if enableTLS == "true" {
+		config.Net.TLS.Enable = true
+	}
+
 	user := os.Getenv("SINK_KAFKA_USER")
 	if user != "" {
 		password := os.Getenv("SINK_KAFKA_PASSWORD")


### PR DESCRIPTION
In order to support in transit TLS encryption without client TLS auth.
For instance can be used with AWS MSK https://docs.aws.amazon.com/msk/latest/developerguide/msk-encryption.html#msk-encryption-in-transit